### PR TITLE
[SC-363] Quantity lock included in the PDP selector

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "vendor": "vtex",
+  "vendor": "marykay",
   "name": "product-quantity",
   "version": "1.9.0",
   "title": "Product Quantity",

--- a/react/components/StepperProductQuantity.tsx
+++ b/react/components/StepperProductQuantity.tsx
@@ -17,7 +17,7 @@ interface StepperProps {
   showUnit: boolean
 }
 
-const CSS_HANDLES = ['quantitySelectorStepper'] as const
+const CSS_HANDLES = ['quantitySelectorStepper', 'limitQuantity'] as const
 
 const StepperProductQuantity: FunctionComponent<StepperProps> = ({
   unitMultiplier = 1,
@@ -29,7 +29,8 @@ const StepperProductQuantity: FunctionComponent<StepperProps> = ({
   showUnit,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
-
+  const maxValueSelected = 99
+  const maxTotalQuantity = availableQuantity < maxValueSelected ? availableQuantity : maxValueSelected
   return (
     <div className={handles.quantitySelectorStepper}>
       <NumericStepper
@@ -43,8 +44,11 @@ const StepperProductQuantity: FunctionComponent<StepperProps> = ({
         }
         onChange={onChange}
         value={selectedQuantity}
-        maxValue={availableQuantity || undefined}
+        maxValue={maxTotalQuantity || undefined}
       />
+    {maxTotalQuantity === selectedQuantity &&
+      (<span className={handles.limitQuantity}>Limite atingido!</span>)
+    }
     </div>
   )
 }


### PR DESCRIPTION
#### Qual é o tipo do problema ?

- [X] Fix
- [ ] Feature
- [ ] Release
- [ ] Docs

#### Qual o problema que está sendo resolvido?
![image](https://github.com/beightone/marykay.store-theme/assets/77762757/5a59f899-74be-4aff-a3f7-b179a9b7b121)

Foi necessário forkar o componente nativo vtex (product-quantity) e subir customização diretamente nele.

#### Como validar:

1. Acesse [WS](https://sc363--marykay.myvtex.com/)
2. Acesse a PDP de algum produto do site
4. Valide a tentativa de adição de mais de 99 itens ao carrinho/minicart

#### Task(s) Relacionada(s):

Essa PR tem como objetivo ajustar o ponto solicitado na [SC-363](https://b8one.atlassian.net/browse/SC-363)